### PR TITLE
releng: matching with upstream and changing cowspc

### DIFF
--- a/live-iso/mkinitcpio.conf
+++ b/live-iso/mkinitcpio.conf
@@ -1,2 +1,2 @@
-HOOKS="base udev memdisk archiso_shutdown archiso archiso_loop_mnt archiso_pxe_common archiso_pxe_nbd archiso_pxe_http archiso_pxe_nfs archiso_kms block pcmcia filesystems keyboard"
+HOOKS=(base udev memdisk archiso_shutdown archiso archiso_loop_mnt archiso_pxe_common archiso_pxe_nbd archiso_pxe_http archiso_pxe_nfs archiso_kms block pcmcia filesystems keyboard)
 COMPRESSION="xz"

--- a/live-iso/syslinux/archiso_sys.cfg
+++ b/live-iso/syslinux/archiso_sys.cfg
@@ -8,6 +8,6 @@ ENDTEXT
 MENU LABEL Boot BlackArch Linux (x86_64)
 LINUX boot/x86_64/vmlinuz
 INITRD boot/intel_ucode.img,boot/x86_64/archiso.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL%
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=60%
 
 INCLUDE boot/syslinux/archiso_tail.cfg


### PR DESCRIPTION
also: 

- cowspace is now 60% of usable RAM.