### PR TITLE
Update packages to inlcude the openbsd-netcat

### DIFF
--- a/slim-iso/packages.x86_64
+++ b/slim-iso/packages.x86_64
@@ -24,7 +24,7 @@ exfatprogs
 f2fs-tools
 fatresize
 fsarchiver
-gnu-netcat
+openbsd-netcat
 gpart
 gpm
 gptfdisk


### PR DESCRIPTION
Hi there :)

Apologies I couldn't connect to the IRC channel to chat about this (might be my work vpn), but I had some troubles with the GNU netcat especially around the try hack me boxes. On some occasions the listen didn't even work when trying to connect to a reverse shell, I also found this during work (I work as a security consultant just for context). I looked into it and the general consensus is that the openbsd-netcat is superior to the GNU netcat due to the myriad of support and frequent updates to the openbsd-netcat compared to the GNU netcat. I've been using it for the last 2 months without issues, it just seems a lot more stable. Would it be possible to replace it for the slim iso? If so would just editing the package file do it (sorry I'm a bit new to linux and pen testing in general)? Let me know!