### PR TITLE
deprecated communty repo deletion

### DIFF
--- a/full-iso/pacman.conf
+++ b/full-iso/pacman.conf
@@ -78,12 +78,6 @@ Include = /etc/pacman.d/mirrorlist
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
-#[community-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-[community]
-Include = /etc/pacman.d/mirrorlist
-
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 

--- a/netinstall-iso/pacman.conf
+++ b/netinstall-iso/pacman.conf
@@ -78,12 +78,6 @@ Include = /etc/pacman.d/mirrorlist
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
-#[community-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-[community]
-Include = /etc/pacman.d/mirrorlist
-
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 

--- a/slim-iso/pacman.conf
+++ b/slim-iso/pacman.conf
@@ -78,12 +78,6 @@ Include = /etc/pacman.d/mirrorlist
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
-#[community-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-[community]
-Include = /etc/pacman.d/mirrorlist
-
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 


### PR DESCRIPTION
Building iso fails due to deprecated community repository in `pacman.conf` files. :smiley_cat: 